### PR TITLE
Grouping Same Titled Books Together 

### DIFF
--- a/src/exsm3951_bookswap/templates/book-listings/my-book-listings.html
+++ b/src/exsm3951_bookswap/templates/book-listings/my-book-listings.html
@@ -23,7 +23,7 @@
 
 <section class="mb-8 mt-8">
   <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-    {% for listing in my_book_listings %}
+    {% for listing in my_book_listings|dictsort:"book.title" %}
     <a href="{% url 'view_book_listing' listing.id %}">
       <div class="bg-white shadow p-3 rounded flex flex-col justify-between">
         <div>


### PR DESCRIPTION
### Summary 

- Modified frontend view for 'My Listing' page to show books with the same title and ISBN grouped together

<img src="https://github.com/user-attachments/assets/2032705b-9a14-4c07-9d6f-9aa50557574d" width="500" />
